### PR TITLE
Stop tracking tags files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ dmypy.json
 
 # Ignore virtual environments
 venv/
+
+# Ignore ctags file
+tags


### PR DESCRIPTION
Vim users might be working with `tags` files for easier code navigation and "goto" definitions. Therefore, let us ignore this file, as it is not critical neither any piece of code or tool depends on it.