### PR TITLE
Fix gauss1809 series order

### DIFF
--- a/src/lamberthub/p_solvers/gauss.py
+++ b/src/lamberthub/p_solvers/gauss.py
@@ -274,7 +274,7 @@ def _gauss_second_equation(x, s):
     return y
 
 
-def _X_at_x(x, order=1):
+def _X_at_x(x, order=50):
     """Computes capital X as function of lower x.
 
     Parameters


### PR DESCRIPTION
I imposed a default low order when evaluating the `X(x)` function in Gauss' solver. This was not triggered by the tests, which made use of a greater order. This bug was noticed while working on the documentation of the algorithm. Hopefully, no more modifications will be made for Gauss' solver for a while...