### PR TITLE
Clean and fix dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,11 +44,9 @@ Tracker = "https://github.com/jorgepiloto/lamberthub/issues"
 
 [project.optional-dependencies]
 dev = [
-    "black==20.8b1",
+    "black",
     "coverage",
     "isort",
-    "docutils<0.17,>=0.12",
-    "markdown-it-py~=0.6.2",
     "myst-nb",
     "notebook",
     "pycodestyle",


### PR DESCRIPTION
This pull request cleans and fixes some dependencies which were not necessary after the documentation theme was migrated from the [sphinx book theme](https://github.com/executablebooks/sphinx-book-theme) to the [read the docs](https://sphinx-rtd-theme.readthedocs.io/en/stable/) one in https://github.com/jorgepiloto/lamberthub/pull/25.