### PR TITLE
Rename notebook files about gauss1809 solver

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -97,7 +97,7 @@ nbsphinx_custom_formats = {
 
 # Custom thumbnails for gallery of examples
 nbsphinx_thumbnails = {
-        "tutorials/gauss_solver": "_static/tutorials/gauss_thumbnail.png"
+        "tutorials/gauss1809_solver": "_static/tutorials/gauss_thumbnail.png"
 }
 
 # The performance comparison takes a bit long. This avoids the documentation to

--- a/docs/source/tutorials/gallery.md
+++ b/docs/source/tutorials/gallery.md
@@ -3,6 +3,6 @@
 ```{eval-rst}
 .. nbgallery::
 
-   gauss_solver.mystnb
+   gauss1809_solver.mystnb
    
 ```

--- a/docs/source/tutorials/gauss1809_solver.mystnb
+++ b/docs/source/tutorials/gauss1809_solver.mystnb
@@ -11,7 +11,7 @@ kernelspec:
   name: python3
 ---
 
-# Gauss' solver and the discovery of Ceres
+# Gauss' 1809 solver and the discovery of Ceres
 
 ![Gauss portrait](../_static/tutorials/gauss_thumbnail.png)
 


### PR DESCRIPTION
Just renamed some of the notebook files about gauss1809 solver, so it is clear which particular algorithms those are pointing. This is because some authors have published more than one solver for solving Lambert's problem, so it is better if we indicate the author name and publication date.