### PR TITLE
feat: accelerate numeric helpers with Numba

### DIFF
--- a/src/lamberthub/ecc_solvers/avanzini.py
+++ b/src/lamberthub/ecc_solvers/avanzini.py
@@ -32,6 +32,7 @@ previous routines.
 
 import time
 
+from numba import njit as jit
 import numpy as np
 from scipy.optimize import newton
 
@@ -152,6 +153,7 @@ def avanzini2008(
     return (v1, v2, numiter, tpi) if full_output is True else (v1, v2)
 
 
+@jit
 def _get_eccT_limits(geometry):
     """
     Computes transverse eccentricity value limits as of problem geometry.

--- a/src/lamberthub/ecc_solvers/utils.py
+++ b/src/lamberthub/ecc_solvers/utils.py
@@ -16,6 +16,7 @@ taken from the following publications [1] [2] [3].
 
 """
 
+from numba import njit as jit
 import numpy as np
 from numpy import cross
 from numpy.linalg import norm
@@ -67,6 +68,7 @@ def get_geometry(r1, r2, prograde):
     return r1_norm, r2_norm, c_norm, dtheta, w_c
 
 
+@jit
 def get_eccF(r1_norm, r2_norm, c_norm):
     """
     Computes the eccentricity component along the chord. This value is kept
@@ -96,6 +98,7 @@ def get_eccF(r1_norm, r2_norm, c_norm):
     return ecc_F
 
 
+@jit
 def get_aF(r1_norm, r2_norm):
     """
     Computes the semi-major axis of the fundamental ellipse. This value is
@@ -124,6 +127,7 @@ def get_aF(r1_norm, r2_norm):
     return a_F
 
 
+@jit
 def get_pF(a_F, ecc_F):
     """
     Computes the orbital parameter (semi-latus) rectum of the fundamental
@@ -151,6 +155,7 @@ def get_pF(a_F, ecc_F):
     return p_F
 
 
+@jit
 def get_fundamental_ellipse_properties(r1_norm, r2_norm, c_norm):
     """
     Computes the fundamental ellipse properties. Those are the eccentricity,
@@ -183,6 +188,7 @@ def get_fundamental_ellipse_properties(r1_norm, r2_norm, c_norm):
     return ecc_F, a_F, p_F
 
 
+@jit
 def ecc_at_eccT(ecc_T, ecc_F):
     """
     Computes transfer orbit eccentricity from transverse and fundamental
@@ -205,6 +211,7 @@ def ecc_at_eccT(ecc_T, ecc_F):
     return ecc
 
 
+@jit
 def p_at_eccT(ecc_T, r1_norm, r2_norm, c_norm, dtheta, p_F):
     """
     Computes the orbital parameter or semi-latus rectum of the transfer orbit.
@@ -234,6 +241,7 @@ def p_at_eccT(ecc_T, r1_norm, r2_norm, c_norm, dtheta, p_F):
     return p
 
 
+@jit
 def a_at_eccT(ecc_T, ecc_F, p):
     """
     Computes the semi-major axis of the transfer orbit.
@@ -257,6 +265,7 @@ def a_at_eccT(ecc_T, ecc_F, p):
     return a
 
 
+@jit
 def eap_from_eccT(ecc_T, geometry):
     """
     Solves for transfer orbit eccentricity, semi-major axis and orbital
@@ -295,6 +304,7 @@ def eap_from_eccT(ecc_T, geometry):
     return ecc, a, p
 
 
+@jit
 def w_at_eccT(ecc_T, ecc_F, w_c):
     """
     Compute the true anomalies for the initial and final position vectors
@@ -331,6 +341,7 @@ def w_at_eccT(ecc_T, ecc_F, w_c):
     return w
 
 
+@jit
 def get_true_anomalies(w, dtheta):
     """
     Compute the initial and final true anomalies.
@@ -355,6 +366,7 @@ def get_true_anomalies(w, dtheta):
     return nu_1, nu_2
 
 
+@jit
 def kepler_tof_at_eccT(ecc_T, mu, geometry):
     """
     Computes the time of flight at particular value of transverse eccentricity

--- a/src/lamberthub/p_solvers/battin.py
+++ b/src/lamberthub/p_solvers/battin.py
@@ -2,6 +2,7 @@
 
 import time
 
+from numba import njit as jit
 import numpy as np
 
 from lamberthub.utils.angles import get_transfer_angle
@@ -160,6 +161,7 @@ def battin1984(
     return (v1, v2, numiter, tpi) if full_output is True else (v1, v2)
 
 
+@jit
 def _battin_first_equation(y, ll, m):
     """Battin's first equation.
 
@@ -187,6 +189,7 @@ def _battin_first_equation(y, ll, m):
     return x
 
 
+@jit
 def _battin_second_equation(u, h1, h2):
     """Battin's second equation.
 
@@ -215,6 +218,7 @@ def _battin_second_equation(u, h1, h2):
     return y
 
 
+@jit
 def _get_lambda(c, s, dtheta):
     """Compute the transfer angle parameter.
 
@@ -242,6 +246,7 @@ def _get_lambda(c, s, dtheta):
     return _lambda
 
 
+@jit
 def _get_ll(_lambda):
     """Computes the l variable.
 
@@ -264,6 +269,7 @@ def _get_ll(_lambda):
     return ll
 
 
+@jit
 def _get_m(mu, tof, s, _lambda):
     """Computes the m auxiliary variable.
 
@@ -292,6 +298,7 @@ def _get_m(mu, tof, s, _lambda):
     return m
 
 
+@jit
 def _get_h_coefficients(x, ll, m):
     """Evaluates the h1 and h2 coefficients.
 
@@ -329,6 +336,7 @@ def _get_h_coefficients(x, ll, m):
     return (h1, h2)
 
 
+@jit
 def _u_at_h(h1, h2):
     """Evaluates u at h coefficients.
 
@@ -349,6 +357,7 @@ def _u_at_h(h1, h2):
     return u
 
 
+@jit
 def _u_at_B(B):
     """Evaluates u auxiliary variable at given B.
 
@@ -371,6 +380,7 @@ def _u_at_B(B):
     return u
 
 
+@jit
 def _B_at_h(h1, h2):
     """Evaluates B auxiliary variable at given h coefficients.
 
@@ -395,6 +405,7 @@ def _B_at_h(h1, h2):
     return B
 
 
+@jit
 def _xi_at_x(x, levels=125):
     """Evaluates the xi function at a particular value of x.
 
@@ -442,6 +453,7 @@ def _xi_at_x(x, levels=125):
     return xi
 
 
+@jit
 def _K_at_u(u, levels=1000):
     """Evaluates the K function at a particular value of u.
 
@@ -482,7 +494,7 @@ def _K_at_u(u, levels=1000):
             u0 = u0 * (delta - 1)
             sigma = sigma + u0
         else:
-            for val in [1, 2]:
+            for val in range(1, 3):
                 if val == 1:
                     gamma = (
                         2

--- a/src/lamberthub/p_solvers/gauss.py
+++ b/src/lamberthub/p_solvers/gauss.py
@@ -2,6 +2,7 @@
 
 import time
 
+from numba import njit as jit
 import numpy as np
 from numpy.linalg import norm
 
@@ -164,6 +165,7 @@ def gauss1809(
     return (v1, v2, numiter, tpi) if full_output is True else (v1, v2)
 
 
+@jit
 def _get_s(r1_norm, r2_norm, dtheta):
     """Returns the s auxiliary constant.
 
@@ -192,6 +194,7 @@ def _get_s(r1_norm, r2_norm, dtheta):
     return s
 
 
+@jit
 def _get_w(mu, tof, r1_norm, r2_norm, dtheta):
     """Returns the w auxiliary constant.
 
@@ -222,6 +225,7 @@ def _get_w(mu, tof, r1_norm, r2_norm, dtheta):
     return w
 
 
+@jit
 def _gauss_first_equation(y, s, w):
     """Evaluates Gauss' first equation.
 
@@ -248,6 +252,7 @@ def _gauss_first_equation(y, s, w):
     return x
 
 
+@jit
 def _gauss_second_equation(x, s):
     """Evaluates Gauss' second equation.
 
@@ -272,6 +277,7 @@ def _gauss_second_equation(x, s):
     return y
 
 
+@jit
 def _X_at_x(x, order=50):
     """Computes capital X as function of lower x.
 
@@ -292,9 +298,10 @@ def _X_at_x(x, order=50):
     This is equation (5.6-15) from Bate's book, in reference [2].
 
     """
-    coefficients = [1]
+    coeff = 1.0
+    X = coeff
     for n in range(3, (3 + order)):
-        coeff = (2 * n) / (2 * n - 1)
-        coefficients.append(np.prod(coefficients[-1]) * coeff * x)
-    X = (4 / 3) * np.sum(coefficients)
+        coeff = coeff * (2 * n) / (2 * n - 1) * x
+        X += coeff
+    X = (4 / 3) * X
     return X

--- a/src/lamberthub/universal_solvers/arora.py
+++ b/src/lamberthub/universal_solvers/arora.py
@@ -2,6 +2,7 @@
 
 import time
 
+from numba import njit as jit
 import numpy as np
 from numpy.linalg import norm
 
@@ -322,6 +323,7 @@ def arora2013(
     return (v1, v2, numiter, tpi) if full_output is True else (v1, v2)
 
 
+@jit
 def _get_gammas(F_i, F_n, F_star):
     """Compute different gamma values"""
     gamma1, gamma2, gamma3 = (
@@ -332,6 +334,7 @@ def _get_gammas(F_i, F_n, F_star):
     return gamma1, gamma2, gamma3
 
 
+@jit
 def _get_x(F_0, F_1, F_i, F_star, Z, alpha):
     """Computes Sundman transformation variable.
 
@@ -367,6 +370,7 @@ def _get_x(F_0, F_1, F_i, F_star, Z, alpha):
     return x
 
 
+@jit
 def _get_W(k, M, epsilon=2e-2):
     """
     Evaluates the auxiliary function at particular value of the independent
@@ -413,7 +417,13 @@ def _get_W(k, M, epsilon=2e-2):
 
         # Allocate auxiliary variables
         v = k - sq2
-        v2, v3, v4, v5, v6, v7, v8 = [v**i for i in range(2, 9)]
+        v2 = v**2
+        v3 = v**3
+        v4 = v**4
+        v5 = v**5
+        v6 = v**6
+        v7 = v**7
+        v8 = v**8
 
         W = (
             (np.sqrt(2) / 3)
@@ -432,6 +442,7 @@ def _get_W(k, M, epsilon=2e-2):
     return W
 
 
+@jit
 def _get_Wsprime(k):
     """Evaluate the first derivative of Ws w.r.t. independent variable k.
 
@@ -454,7 +465,12 @@ def _get_Wsprime(k):
     # Allocate auxiliary variables
     sq2 = np.sqrt(2)
     v = k - sq2
-    v2, v3, v4, v5, v6, v7 = [v**i for i in range(2, 8)]
+    v2 = v**2
+    v3 = v**3
+    v4 = v**4
+    v5 = v**5
+    v6 = v**6
+    v7 = v**7
 
     Ws_prime = (
         -1 / 5
@@ -470,6 +486,7 @@ def _get_Wsprime(k):
     return Ws_prime
 
 
+@jit
 def _get_Ws2prime(k):
     """Evaluate the second derivative of Ws w.r.t. independent variable k.
 
@@ -492,7 +509,11 @@ def _get_Ws2prime(k):
     # Allocate auxiliary variables
     sq2 = np.sqrt(2)
     v = k - sq2
-    v2, v3, v4, v5, v6 = [v**i for i in range(2, 7)]
+    v2 = v**2
+    v3 = v**3
+    v4 = v**4
+    v5 = v**5
+    v6 = v**6
 
     Ws_2prime = (
         sq2 * (4 / 35)
@@ -507,6 +528,7 @@ def _get_Ws2prime(k):
     return Ws_2prime
 
 
+@jit
 def _get_Wprime(k, W, epsilon=2e-2):
     """
     Evaluates the first derivative of the auxiliary function w.r.t. the
@@ -551,6 +573,7 @@ def _get_Wprime(k, W, epsilon=2e-2):
     return W_prime
 
 
+@jit
 def _get_W2prime(k, W, W_prime, epsilon=2e-2):
     """
     Evaluates the second derivative of the auxiliary function w.r.t. the
@@ -595,6 +618,7 @@ def _get_W2prime(k, W, W_prime, epsilon=2e-2):
     return W_2prime
 
 
+@jit
 def _get_TOF(k, tau, S, W):
     """Evaluates the time of flight at a particular value of the independent variable.
 

--- a/src/lamberthub/universal_solvers/gooding.py
+++ b/src/lamberthub/universal_solvers/gooding.py
@@ -2,6 +2,7 @@
 
 import time
 
+from numba import njit as jit
 import numpy as np
 from numpy.linalg import norm
 
@@ -135,6 +136,13 @@ def gooding1990(
     return (v1, v2, numiter, tpi) if full_output is True else (v1, v2)
 
 
+@jit
+def _d8rt(x):
+    """Compute the eighth root of a positive scalar."""
+    return np.sqrt(np.sqrt(np.sqrt(x)))
+
+
+@jit
 def tlamb(m, q, qsqfm1, x, n):
     """
     Auxiliary routine for computing the non-dimensional time of flight as
@@ -389,11 +397,6 @@ def xlamb(m, q, qsqfm1, tin, maxiter, atol, rtol):
     # Boolean variables to emulate original code as max as possible.
     goto3 = False
 
-    # Auxiliary function for 8th root.
-    def d8rt(x):
-        """Compute the eighth root of a positive scalar."""
-        return np.sqrt(np.sqrt(np.sqrt(x)))
-
     # Start computing the initial guess. The process is different depending
     # on the number of revolutions.
     if m == 0:
@@ -412,7 +415,7 @@ def xlamb(m, q, qsqfm1, tin, maxiter, atol, rtol):
             w = x + c0 * np.sqrt(2.0 * (1.0 - thr2))
 
             if w < 0.0:
-                x = x - np.sqrt(d8rt(-w)) * (x + np.sqrt(tdiff / (tdiff + 1.5 * t0)))
+                x = x - np.sqrt(_d8rt(-w)) * (x + np.sqrt(tdiff / (tdiff + 1.5 * t0)))
 
             w = 4.0 / (4.0 + tdiff)
             x = x * (1.0 + x * (c1 * w - c2 * x * np.sqrt(w)))
@@ -422,9 +425,9 @@ def xlamb(m, q, qsqfm1, tin, maxiter, atol, rtol):
         xm = 1.0 / (1.5 * (m + 0.5) * np.pi)
 
         if thr2 < 0.5:
-            xm = d8rt(2.0 * thr2) * xm
+            xm = _d8rt(2.0 * thr2) * xm
         if thr2 > 0.5:
-            xm = (2.0 - d8rt(2.0 - 2.0 * thr2)) * xm
+            xm = (2.0 - _d8rt(2.0 - 2.0 * thr2)) * xm
 
         # For locating Tmin, an iterative process is required. Original
         # implementation imposed 12 iterations but they were not considered to
@@ -537,7 +540,7 @@ def xlamb(m, q, qsqfm1, tin, maxiter, atol, rtol):
             w = x + c0 * np.sqrt(2.0 * (1.0 - thr2))
 
             if w < 0.0:
-                x = x - np.sqrt(d8rt(-w)) * (x + np.sqrt(tdiff / (tdiff + 1.5 * t0)))
+                x = x - np.sqrt(_d8rt(-w)) * (x + np.sqrt(tdiff / (tdiff + 1.5 * t0)))
 
             w = 4.0 / (4.0 + tdiff)
             x = x * (

--- a/src/lamberthub/universal_solvers/vallado.py
+++ b/src/lamberthub/universal_solvers/vallado.py
@@ -2,6 +2,7 @@
 
 import time
 
+from numba import njit as jit
 import numpy as np
 
 from lamberthub.utils.angles import get_transfer_angle
@@ -145,6 +146,7 @@ def vallado2013(
     return (v1, v2, numiter, tpi) if full_output is True else (v1, v2)
 
 
+@jit
 def _tof_vallado(mu, psi, X, A, y):
     """Evaluates universal Kepler's equation.
 
@@ -171,6 +173,7 @@ def _tof_vallado(mu, psi, X, A, y):
     return tof
 
 
+@jit
 def _X_at_psi(psi, y):
     """Computes the value of X at given psi.
 
@@ -191,6 +194,7 @@ def _X_at_psi(psi, y):
     return X
 
 
+@jit
 def _get_A(r1_norm, r2_norm, dtheta):
     """Computes the value of the A constant.
 
@@ -214,6 +218,7 @@ def _get_A(r1_norm, r2_norm, dtheta):
     return A
 
 
+@jit
 def _y_at_psi(psi, r1_norm, r2_norm, A):
     """Evaluates the value of y at given psi.
 

--- a/src/lamberthub/utils/elements.py
+++ b/src/lamberthub/utils/elements.py
@@ -15,13 +15,15 @@ References
 
 """
 
+from numba import njit as jit
 import numpy as np
 from numpy import cos, cross, sin, sqrt
-from numpy.linalg import norm
 
+from lamberthub.linalg import dot
 from lamberthub.utils.angles import E_to_nu, H_to_nu
 
 
+@jit
 def rv_pqw(k, p, ecc, nu):
     r"""Return r and v vectors in perifocal frame.
 
@@ -69,6 +71,7 @@ def rv_pqw(k, p, ecc, nu):
     return pqw
 
 
+@jit
 def coe_rotation_matrix(inc, raan, argp):
     """Create a rotation matrix for coe transformation."""
     r = rotation_matrix(raan, 2)
@@ -77,6 +80,7 @@ def coe_rotation_matrix(inc, raan, argp):
     return r
 
 
+@jit
 def coe2rv(k, p, ecc, inc, raan, argp, nu):
     r"""Convert from classical orbital to state vectors.
 
@@ -140,6 +144,7 @@ def coe2rv(k, p, ecc, inc, raan, argp, nu):
     return ijk
 
 
+@jit
 def rv2coe(k, r, v, tol=1e-8):
     r"""Convert from vectors to classical orbital elements.
 
@@ -224,11 +229,14 @@ def rv2coe(k, r, v, tol=1e-8):
 
     """
     h = cross(r, v)
-    n = cross([0, 0, 1], h)
-    e = ((v.dot(v) - k / (norm(r))) * r - r.dot(v) * v) / k
-    ecc = norm(e)
-    p = h.dot(h) / k
-    inc = np.arccos(h[2] / norm(h))
+    n = cross(np.array([0.0, 0.0, 1.0]), h)
+    r_norm = sqrt(dot(r, r))
+    v_norm = sqrt(dot(v, v))
+    h_norm = sqrt(dot(h, h))
+    e = ((dot(v, v) - k / r_norm) * r - dot(r, v) * v) / k
+    ecc = sqrt(dot(e, e))
+    p = dot(h, h) / k
+    inc = np.arccos(h[2] / h_norm)
 
     circular = ecc < tol
     equatorial = abs(inc) < tol
@@ -236,12 +244,12 @@ def rv2coe(k, r, v, tol=1e-8):
     if equatorial and not circular:
         raan = 0
         argp = np.arctan2(e[1], e[0]) % (2 * np.pi)  # Longitude of periapsis
-        nu = np.arctan2(h.dot(cross(e, r)) / norm(h), r.dot(e))
+        nu = np.arctan2(dot(h, cross(e, r)) / h_norm, dot(r, e))
     elif not equatorial and circular:
         raan = np.arctan2(n[1], n[0]) % (2 * np.pi)
         argp = 0
         # Argument of latitude
-        nu = np.arctan2(r.dot(cross(h, n)) / norm(h), r.dot(n))
+        nu = np.arctan2(dot(r, cross(h, n)) / h_norm, dot(r, n))
     elif equatorial and circular:
         raan = 0
         argp = 0
@@ -250,17 +258,17 @@ def rv2coe(k, r, v, tol=1e-8):
         a = p / (1 - (ecc**2))
         ka = k * a
         if a > 0:
-            e_se = r.dot(v) / sqrt(ka)
-            e_ce = norm(r) * v.dot(v) / k - 1
+            e_se = dot(r, v) / sqrt(ka)
+            e_ce = r_norm * dot(v, v) / k - 1
             nu = E_to_nu(np.arctan2(e_se, e_ce), ecc)
         else:
-            e_sh = r.dot(v) / sqrt(-ka)
-            e_ch = norm(r) * (norm(v) ** 2) / k - 1
+            e_sh = dot(r, v) / sqrt(-ka)
+            e_ch = r_norm * (v_norm**2) / k - 1
             nu = H_to_nu(np.log((e_ch + e_sh) / (e_ch - e_sh)) / 2, ecc)
 
         raan = np.arctan2(n[1], n[0]) % (2 * np.pi)
-        px = r.dot(n)
-        py = r.dot(cross(h, n)) / norm(h)
+        px = dot(r, n)
+        py = dot(r, cross(h, n)) / h_norm
         argp = (np.arctan2(py, px) - nu) % (2 * np.pi)
 
     nu = (nu + np.pi) % (2 * np.pi) - np.pi
@@ -268,6 +276,7 @@ def rv2coe(k, r, v, tol=1e-8):
     return p, ecc, inc, raan, argp, nu
 
 
+@jit
 def rotation_matrix(angle, axis):
     """Return a rotation matrix for a certain angle around an axis.
 

--- a/src/lamberthub/utils/kepler.py
+++ b/src/lamberthub/utils/kepler.py
@@ -12,11 +12,13 @@ References
 
 """
 
+from numba import njit as jit
 import numpy as np
 
 from lamberthub.utils.angles import nu_to_B, nu_to_E, nu_to_H
 
 
+@jit
 def kepler_elliptic(E, ecc):
     """Compute the time since perigee passage at given eccentric anomaly.
 
@@ -37,6 +39,7 @@ def kepler_elliptic(E, ecc):
     return M
 
 
+@jit
 def kepler_parabolic(B):
     """Compute the time since perigee passage at given parabolic anomaly.
 
@@ -55,6 +58,7 @@ def kepler_parabolic(B):
     return Mp
 
 
+@jit
 def kepler_hyperbolic(H, ecc):
     """Compute the time since perigee passage at given hyperbolic anomaly.
 
@@ -75,6 +79,7 @@ def kepler_hyperbolic(H, ecc):
     return Mh
 
 
+@jit
 def kepler_from_nu(nu: float, ecc: float) -> float:
     """Compute the mean anomaly at a given true anomaly.
 


### PR DESCRIPTION
## Summary
- decorate Numba-compatible Lambert helper routines across solver families and orbital utilities
- replace a few Python list/closure patterns with nopython-friendly scalar loops/helpers
- keep SciPy callback and timing wrappers in Python where Numba cannot compile them cleanly

Closes #18.

## Tests
- pytest -q
- pre-commit hooks during commit: ruff, ruff-format, codespell, interrogate