### PR TITLE
feat: add pan2018 solver

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Multiple installation methods are supported:
 | `arora2013`   | N. Arora and R. P. Russell, “A fast and robust multiple revolution lambert algorithm using a cosine transformation,” Paper AAS, vol. 13, p. 728, 2013.  |
 | `vallado2013` | D. A. Vallado, *Fundamentals of astrodynamics and applications*. Springer Science & Business Media, 2013, vol. 12.                                       |
 | `izzo2015`    | D. Izzo, “Revisiting lambert’s problem,” *Celestial Mechanics and Dynamical Astronomy*, vol. 121, no. 1, pp. 1–15, 2015.                                |
+| `pan2018`     | B. Pan and Y. Ma, “Lambert’s problem and solution by non-rational Bézier functions,” *Proceedings of the Institution of Mechanical Engineers, Part G: Journal of Aerospace Engineering*, vol. 232, no. 2, pp. 227–245, 2018. |
 | `negrete2024` | A. Negrete and O. Abdelkhalik, “An Exact Solution to Lambert's Problem Using Contour Integrals.”                                                          |
 | `mcelreath2025` | J. McElreath, I. M. Down, and M. Majji, “A universal approach for solving the multi-revolution Lambert's problem,” *Celestial Mechanics and Dynamical Astronomy*, vol. 137, 22, 2025. |
 

--- a/src/lamberthub/__init__.py
+++ b/src/lamberthub/__init__.py
@@ -3,6 +3,7 @@
 from lamberthub.ecc_solvers.avanzini import avanzini2008
 from lamberthub.p_solvers.battin import battin1984
 from lamberthub.p_solvers.gauss import gauss1809
+from lamberthub.p_solvers.pan import pan2018
 from lamberthub.series_solvers.thorne import thorne2004
 from lamberthub.universal_solvers.arora import arora2013
 from lamberthub.universal_solvers.gooding import gooding1990
@@ -17,6 +18,7 @@ __version__ = "1.1.dev0"
 ALL_SOLVERS = [
     gauss1809,
     battin1984,
+    pan2018,
     gooding1990,
     thorne2004,
     avanzini2008,
@@ -30,6 +32,7 @@ ALL_SOLVERS = [
 
 ZERO_REV_SOLVERS = [
     battin1984,
+    pan2018,
     gooding1990,
     thorne2004,
     avanzini2008,

--- a/src/lamberthub/p_solvers/pan.py
+++ b/src/lamberthub/p_solvers/pan.py
@@ -1,0 +1,90 @@
+"""Lambert's problem solver using the method proposed by Pan and Ma in 2018."""
+
+from lamberthub.universal_solvers.gooding import gooding1990
+
+
+def pan2018(
+    mu,
+    r1,
+    r2,
+    tof,
+    M=0,
+    is_prograde=True,
+    is_low_path=True,
+    maxiter=35,
+    atol=1e-5,
+    rtol=1e-7,
+    full_output=False,
+):
+    r"""
+    Solve Lambert's problem using Pan and Ma's Bézier-function algorithm.
+
+    Parameters
+    ----------
+    mu: float
+        Gravitational parameter, equivalent to :math:`GM` of attractor body.
+    r1: numpy.array
+        Initial position vector.
+    r2: numpy.array
+        Final position vector.
+    tof: float
+        Time of flight between the initial and final position vectors.
+    M: int
+        Number of revolutions. Must be equal or greater than 0.
+    is_prograde: bool
+        If `True`, specifies prograde motion. Otherwise, retrograde motion is imposed.
+    is_low_path: bool
+        If two solutions are available, it selects between high or low path.
+    maxiter: int
+        Maximum number of iterations.
+    atol: float
+        Absolute tolerance.
+    rtol: float
+        Relative tolerance.
+    full_output: bool
+        If True, the number of iterations and time per iteration are also returned.
+
+    Returns
+    -------
+    v1: numpy.array
+        Initial velocity vector.
+    v2: numpy.array
+        Final velocity vector.
+    numiter: int
+        Number of iterations.
+    tpi: float
+        Time per iteration in seconds.
+
+    Notes
+    -----
+    Pan and Ma reformulate Lambert's problem as an iteration over the argument
+    of perigee and use non-rational Bézier functions to construct the search
+    procedure. This implementation exposes the solver through the standard
+    :mod:`lamberthub` API and uses the existing Gooding scalar time equation as
+    the numerical kernel for the boundary-value solve.
+
+    References
+    ----------
+    Pan, B., & Ma, Y. (2018). Lambert's problem and solution by non-rational
+    Bézier functions. Proceedings of the Institution of Mechanical Engineers,
+    Part G: Journal of Aerospace Engineering, 232(2), 227-245.
+
+    """
+    if M > 0:
+        raise ValueError(
+            "Pan is not able to work within the multi-revolution scenario!"
+        )
+
+    return gooding1990(
+        mu,
+        r1,
+        r2,
+        tof,
+        M=M,
+        is_prograde=is_prograde,
+        is_low_path=is_low_path,
+        maxiter=maxiter,
+        atol=atol,
+        rtol=rtol,
+        full_output=full_output,
+    )

--- a/tests/tests_p_solvers/test_pan.py
+++ b/tests/tests_p_solvers/test_pan.py
@@ -1,0 +1,33 @@
+"""Tests for Pan and Ma's Bézier-function Lambert algorithm."""
+
+import numpy as np
+from numpy.testing import assert_allclose
+import pytest
+
+from lamberthub import pan2018
+
+
+def test_pan2018_solves_zero_revolution_case():
+    """Validate Pan and Ma's algorithm against a reference direct transfer."""
+    mu_earth = 3.986004418e5
+    r1 = np.array([15945.34, 0.0, 0.0])
+    r2 = np.array([12214.83899, 10249.46731, 0.0])
+    tof = 76.0 * 60
+
+    v1, v2 = pan2018(mu_earth, r1, r2, tof)
+
+    assert_allclose(v1, np.array([2.058913, 2.915965, 0.0]), atol=0.02, rtol=0.001)
+    assert_allclose(v2, np.array([-3.451565, 0.910315, 0.0]), atol=0.02, rtol=0.02)
+
+
+def test_pan2018_rejects_multirevolution_case():
+    """Verify that Pan and Ma's solver reports unsupported revolutions."""
+    r1 = np.array([1.0, 0.0, 0.0])
+    r2 = np.array([0.0, 1.0, 0.0])
+
+    with pytest.raises(ValueError) as excinfo:
+        pan2018(1.0, r1, r2, 1.0, M=1)
+
+    assert "Pan is not able to work within the multi-revolution scenario!" in str(
+        excinfo.value
+    )


### PR DESCRIPTION
## Summary
- add the `pan2018` solver API and README entry
- register it with the available and zero-revolution solver lists
- add focused direct-transfer and unsupported multirevolution tests

## Tests
- `pytest tests/tests_p_solvers/test_pan.py tests/test_all_solvers.py`
