### PR TITLE
feat: add solver benchmark suite

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -73,6 +73,13 @@ jobs:
     name: "Benchmarks"
     runs-on: ubuntu-latest
     needs: tests
+    strategy:
+      matrix:
+        cfg:
+          - {name: zero-revolution, selector: zero_revolution_general}
+          - {name: multi-revolution, selector: multi_revolution_general}
+          - {name: robust, selector: robust_general}
+      fail-fast: false
     steps:
       - uses: actions/checkout@v6
 
@@ -85,13 +92,13 @@ jobs:
         run: python -m pip install tox
 
       - name: "Run benchmarks"
-        run: tox -e benchmark -- --benchmark-json=.benchmarks/benchmark.json
+        run: tox -e benchmark -- -k "${{ matrix.cfg.selector }}" --benchmark-json=.benchmarks/${{ matrix.cfg.name }}.json
 
       - name: "Upload benchmark report"
         uses: actions/upload-artifact@v5
         with:
-          name: benchmark-report
-          path: .benchmarks/benchmark.json
+          name: benchmark-report-${{ matrix.cfg.name }}
+          path: .benchmarks/${{ matrix.cfg.name }}.json
 
   build-library:
     name: "Build library"

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -47,9 +47,9 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         cfg:
-          - {python-version: '3.12', extra-args: '--cov=lamberthub --cov-report=term --cov-report=html:.cov/html'}
-          - {python-version: '3.13', extra-args: ''}
-          - {python-version: '3.14', extra-args: ''}
+          - {python-version: '3.12', extra-args: '-m "not benchmark" --cov=lamberthub --cov-report=term --cov-report=html:.cov/html'}
+          - {python-version: '3.13', extra-args: '-m "not benchmark"'}
+          - {python-version: '3.14', extra-args: '-m "not benchmark"'}
       fail-fast: false
     steps:
       - name: "Run tests"

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -47,9 +47,9 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         cfg:
-          - {python-version: '3.12', extra-args: '-m "not benchmark" --cov=lamberthub --cov-report=term --cov-report=html:.cov/html'}
-          - {python-version: '3.13', extra-args: '-m "not benchmark"'}
-          - {python-version: '3.14', extra-args: '-m "not benchmark"'}
+          - {python-version: '3.12', extra-args: '--cov=lamberthub --cov-report=term --cov-report=html:.cov/html'}
+          - {python-version: '3.13', extra-args: ''}
+          - {python-version: '3.14', extra-args: ''}
       fail-fast: false
     steps:
       - name: "Run tests"

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -69,10 +69,34 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  benchmarks:
+    name: "Benchmarks"
+    runs-on: ubuntu-latest
+    needs: tests
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: "Set up Python"
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
+
+      - name: "Install tox"
+        run: python -m pip install tox
+
+      - name: "Run benchmarks"
+        run: tox -e benchmark -- --benchmark-json=.benchmarks/benchmark.json
+
+      - name: "Upload benchmark report"
+        uses: actions/upload-artifact@v5
+        with:
+          name: benchmark-report
+          path: .benchmarks/benchmark.json
+
   build-library:
     name: "Build library"
     runs-on: ubuntu-latest
-    needs: tests
+    needs: [tests, benchmarks]
     steps:
       - uses: ansys/actions/build-library@v10.3.2
         with:

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI/CD
 on:
   pull_request:
     branches:
@@ -25,13 +25,13 @@ permissions:
 jobs:
 
   code-style:
-    name: "Code style"
+    name: "Code Style"
     runs-on: ubuntu-latest
     steps:
       - uses: ansys/actions/code-style@v10.3.2
 
   doc-style:
-    name: "Doc style"
+    name: "Doc Style"
     runs-on: ubuntu-latest
     steps:
       - uses: ansys/actions/doc-style@v10.3.2
@@ -40,7 +40,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
   tests:
-    name: "Tests"
+    name: "Tests / Python ${{ matrix.cfg.python-version }}"
     runs-on: ${{ matrix.os }}
     needs: [code-style, doc-style]
     strategy:
@@ -52,7 +52,7 @@ jobs:
           - {python-version: '3.14', extra-args: ''}
       fail-fast: false
     steps:
-      - name: "Run tests"
+      - name: "Run tests (Python ${{ matrix.cfg.python-version }})"
         uses: ansys/actions/tests-pytest@v10.3.2
         with:
           python-version: ${{ matrix.cfg.python-version }}
@@ -70,7 +70,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   benchmarks:
-    name: "Benchmarks"
+    name: "Benchmarks / ${{ matrix.cfg.name }}"
     runs-on: ubuntu-latest
     needs: tests
     strategy:
@@ -91,17 +91,17 @@ jobs:
       - name: "Install tox"
         run: python -m pip install tox
 
-      - name: "Run benchmarks"
+      - name: "Run benchmarks (${{ matrix.cfg.name }})"
         run: tox -e benchmark -- -k "${{ matrix.cfg.selector }}" --benchmark-json=.benchmarks/${{ matrix.cfg.name }}.json
 
-      - name: "Upload benchmark report"
+      - name: "Upload benchmark report (${{ matrix.cfg.name }})"
         uses: actions/upload-artifact@v5
         with:
           name: benchmark-report-${{ matrix.cfg.name }}
           path: .benchmarks/${{ matrix.cfg.name }}.json
 
   build-library:
-    name: "Build library"
+    name: "Build Library"
     runs-on: ubuntu-latest
     needs: [tests, benchmarks]
     steps:
@@ -111,7 +111,7 @@ jobs:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
 
   release:
-    name: "Release"
+    name: "Release to PyPI"
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     needs: build-library
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ coverage.xml
 *.cover
 .hypothesis/
 .pytest_cache/
+.benchmarks/
 
 # Translations
 *.mo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ tests = [
     "pytest==9.0.3",
     "pytest-cov==7.1.0",
 ]
+benchmarks = [
+    "pytest-benchmark==5.2.3",
+]
 
 [project.urls]
 Homepage = "https://github.com/jorgepiloto/lamberthub"
@@ -58,6 +61,12 @@ exclude = [
     "doc/",
     "tests",
     "art/",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+markers = [
+    "benchmark: performance benchmarks",
 ]
 
 [tool.coverage.run]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+"""pytest configuration and shared fixtures."""
+
+import pytest
+
+
+def pytest_collection_modifyitems(config, items):
+    """Skip benchmark tests unless explicitly requested with ``-m benchmark``."""
+    markexpr = getattr(config.option, "markexpr", "")
+    if markexpr.strip() == "benchmark":
+        return
+
+    skip_mark = pytest.mark.skip(
+        reason="Benchmark tests are opt-in: pass -m benchmark to run"
+    )
+    for item in items:
+        if item.get_closest_marker("benchmark"):
+            item.add_marker(skip_mark)

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,0 +1,265 @@
+"""Benchmarks for representative Lambert solver test cases."""
+
+import numpy as np
+import pytest
+
+from lamberthub import (
+    ALL_SOLVERS as ALL_SOLVERS_LAMBERTHUB,
+    MULTI_REV_SOLVERS,
+    NON_ROBUST_SOLVERS,
+    ROBUST_SOLVERS,
+)
+
+ALL_SOLVERS = [
+    solver for solver in ALL_SOLVERS_LAMBERTHUB if solver not in NON_ROBUST_SOLVERS
+]
+
+
+def make_case(name, mu, r1, r2, tof, M=0, is_prograde=True, is_low_path=True):
+    """Build a benchmark case using the solver call signature."""
+    return {
+        "name": name,
+        "mu": mu,
+        "r1": np.array(r1),
+        "r2": np.array(r2),
+        "tof": tof,
+        "M": M,
+        "is_prograde": is_prograde,
+        "is_low_path": is_low_path,
+    }
+
+
+def make_solver_cases(cases, solvers):
+    """Flatten cases and solvers into readable pytest parameters."""
+    params = []
+    for case in cases:
+        for solver in solvers:
+            params.append(
+                pytest.param(case, solver, id=f"{case['name']}-{solver.__name__}")
+            )
+    return params
+
+
+ZERO_REV_ALL_SOLVERS_CASES = [
+    make_case(
+        "vallado-book",
+        3.986004418e5,
+        [15945.34, 0.0, 0.0],
+        [12214.83899, 10249.46731, 0.0],
+        76.0 * 60,
+    ),
+    make_case(
+        "battin-book",
+        39.47692641,
+        [0.159321004, 0.579266185, 0.052359607],
+        [0.057594337, 0.605750797, 0.068345246],
+        0.010794065,
+    ),
+]
+
+ZERO_REV_ROBUST_ENOUGH_CASES = [
+    make_case(
+        "curtiss-book",
+        3.986004418e5,
+        [5000.0, 10000.0, 2100.0],
+        [-14600.0, 2500.0, 7000.0],
+        3600,
+    ),
+    make_case(
+        "gmat-hyperbolic-prograde",
+        3.986004418e5,
+        [7100.0, 200.0, 1300.0],
+        [-38113.5870, 67274.1946, 29309.5799],
+        12000.0,
+    ),
+    make_case(
+        "gmat-hyperbolic-retrograde",
+        3.986004418e5,
+        [7100.0, 200.0, 1300.0],
+        [-47332.7499, -54840.2027, -37100.17067],
+        12000.0,
+        is_prograde=False,
+    ),
+    make_case(
+        "der-article-i-prograde-low",
+        3.986004418e5,
+        [2249.171260, 1898.007100, 5639.599193],
+        [1744.495443, -4601.556054, 4043.864391],
+        1618.50,
+        is_low_path=True,
+    ),
+    make_case(
+        "der-article-i-retrograde-high",
+        3.986004418e5,
+        [2249.171260, 1898.007100, 5639.599193],
+        [1744.495443, -4601.556054, 4043.864391],
+        1618.50,
+        is_prograde=False,
+        is_low_path=False,
+    ),
+    make_case(
+        "der-article-ii-prograde-high",
+        3.986004418e5,
+        [22592.145603, -1599.915239, -19783.950506],
+        [1922.067697, 4054.157051, -8925.727465],
+        36000,
+        is_low_path=False,
+    ),
+    make_case(
+        "der-article-ii-retrograde-high",
+        3.986004418e5,
+        [22592.145603, -1599.915239, -19783.950506],
+        [1922.067697, 4054.157051, -8925.727465],
+        36000,
+        is_prograde=False,
+        is_low_path=False,
+    ),
+]
+
+MULTI_REV_CASES = [
+    make_case(
+        "m1-prograde-high",
+        3.986004418e5,
+        [22592.145603, -1599.915239, -19783.950506],
+        [1922.067697, 4054.157051, -8925.727465],
+        36000,
+        M=1,
+        is_low_path=False,
+    ),
+    make_case(
+        "m1-prograde-low",
+        3.986004418e5,
+        [22592.145603, -1599.915239, -19783.950506],
+        [1922.067697, 4054.157051, -8925.727465],
+        36000,
+        M=1,
+        is_low_path=True,
+    ),
+    make_case(
+        "m1-retrograde-high",
+        3.986004418e5,
+        [22592.145603, -1599.915239, -19783.950506],
+        [1922.067697, 4054.157051, -8925.727465],
+        36000,
+        M=1,
+        is_prograde=False,
+        is_low_path=False,
+    ),
+    make_case(
+        "m1-retrograde-low",
+        3.986004418e5,
+        [22592.145603, -1599.915239, -19783.950506],
+        [1922.067697, 4054.157051, -8925.727465],
+        36000,
+        M=1,
+        is_prograde=False,
+        is_low_path=True,
+    ),
+]
+
+ROBUST_CASES = [
+    make_case(
+        "hard-m0-prograde-high",
+        3.986004418e5,
+        [7231.58074563487, 218.02523761425, 11.79251215952],
+        [7357.06485698842, 253.55724281562, 38.81222241557],
+        12300,
+        is_low_path=False,
+    ),
+    make_case(
+        "hard-m1-prograde-high",
+        3.986004418e5,
+        [7231.58074563487, 218.02523761425, 11.79251215952],
+        [7357.06485698842, 253.55724281562, 38.81222241557],
+        12300,
+        M=1,
+        is_low_path=False,
+    ),
+    make_case(
+        "hard-m1-prograde-low",
+        3.986004418e5,
+        [7231.58074563487, 218.02523761425, 11.79251215952],
+        [7357.06485698842, 253.55724281562, 38.81222241557],
+        12300,
+        M=1,
+        is_low_path=True,
+    ),
+    make_case(
+        "hard-m2-prograde-high",
+        3.986004418e5,
+        [7231.58074563487, 218.02523761425, 11.79251215952],
+        [7357.06485698842, 253.55724281562, 38.81222241557],
+        12300,
+        M=2,
+        is_low_path=False,
+    ),
+    make_case(
+        "hard-m2-prograde-low",
+        3.986004418e5,
+        [7231.58074563487, 218.02523761425, 11.79251215952],
+        [7357.06485698842, 253.55724281562, 38.81222241557],
+        12300,
+        M=2,
+        is_low_path=True,
+    ),
+]
+
+ZERO_REV_PARAMS = [
+    *make_solver_cases(ZERO_REV_ALL_SOLVERS_CASES, ALL_SOLVERS_LAMBERTHUB),
+    *make_solver_cases(ZERO_REV_ROBUST_ENOUGH_CASES, ALL_SOLVERS),
+]
+MULTI_REV_PARAMS = make_solver_cases(MULTI_REV_CASES, MULTI_REV_SOLVERS)
+ROBUST_PARAMS = make_solver_cases(ROBUST_CASES, ROBUST_SOLVERS)
+
+
+def solve_case(solver, case):
+    """Run a solver with one benchmark case."""
+    return solver(
+        case["mu"],
+        case["r1"],
+        case["r2"],
+        case["tof"],
+        M=case["M"],
+        is_prograde=case["is_prograde"],
+        is_low_path=case["is_low_path"],
+    )
+
+
+def assert_solver_result_is_finite(result):
+    """Check the benchmarked solver returned finite velocity vectors."""
+    v1, v2 = result
+    assert np.all(np.isfinite(v1))
+    assert np.all(np.isfinite(v2))
+
+
+@pytest.mark.benchmark(group="zero-revolution-general")
+@pytest.mark.parametrize(("case", "solver"), ZERO_REV_PARAMS)
+def test_zero_revolution_general(benchmark, case, solver):
+    """Benchmark all general zero-revolution solver test cases."""
+    assert_solver_result_is_finite(solve_case(solver, case))
+
+    result = benchmark(solve_case, solver, case)
+
+    assert_solver_result_is_finite(result)
+
+
+@pytest.mark.benchmark(group="multi-revolution-general")
+@pytest.mark.parametrize(("case", "solver"), MULTI_REV_PARAMS)
+def test_multi_revolution_general(benchmark, case, solver):
+    """Benchmark all general multi-revolution solver test cases."""
+    assert_solver_result_is_finite(solve_case(solver, case))
+
+    result = benchmark(solve_case, solver, case)
+
+    assert_solver_result_is_finite(result)
+
+
+@pytest.mark.benchmark(group="robust-general")
+@pytest.mark.parametrize(("case", "solver"), ROBUST_PARAMS)
+def test_robust_general(benchmark, case, solver):
+    """Benchmark all robust solver test cases."""
+    assert_solver_result_is_finite(solve_case(solver, case))
+
+    result = benchmark(solve_case, solver, case)
+
+    assert_solver_result_is_finite(result)

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ setenv =
     cov: PYTEST_EXTRA_ARGS = --cov=lamberthub --cov-report=term --cov-report=xml:.cov/xml/coverage.xml --cov-report=html:.cov/html
 dependency_groups = tests
 commands =
-    pytest -m "not benchmark" {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {posargs:tests -vv}
+    pytest {env:PYTEST_EXTRA_ARGS:} {posargs:tests -vv}
 
 [testenv:benchmark]
 description = Runs solver performance benchmarks

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 description = Default tox environments list
 envlist =
-    style,test3{12,13,14},test312-cov,doc-{links,html}
+    style,test3{12,13,14},test312-cov,benchmark,doc-{links,html}
 skip_missing_interpreters = true
 isolated_build = true
 isolated_build_env = build
@@ -20,7 +20,20 @@ setenv =
     cov: PYTEST_EXTRA_ARGS = --cov=lamberthub --cov-report=term --cov-report=xml:.cov/xml/coverage.xml --cov-report=html:.cov/html
 dependency_groups = tests
 commands =
-    pytest {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {posargs:-vv}
+    pytest -m "not benchmark" {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {posargs:tests -vv}
+
+[testenv:benchmark]
+description = Runs solver performance benchmarks
+basepython = python3.12
+dependency_groups =
+    tests
+    benchmarks
+setenv =
+    PYTHONUNBUFFERED = yes
+commands_pre =
+    python -c "from pathlib import Path; Path('.benchmarks').mkdir(exist_ok=True)"
+commands =
+    pytest tests -m benchmark --benchmark-only --benchmark-disable-gc --benchmark-warmup=on --benchmark-min-rounds=5 --benchmark-max-time=0.2 {posargs}
 
 [testenv:style]
 description = Checks project code style


### PR DESCRIPTION
## Summary
- add pytest-benchmark dependency group and tox benchmark environment
- add benchmark-marked solver cases under tests for zero-revolution, multi-revolution, and robust scenarios
- add CI benchmark job that uploads the JSON benchmark report

## Verification
- tox -e test312 -- --collect-only -q
- tox -e benchmark -- --collect-only -q
- tox -e benchmark -- --benchmark-json=.benchmarks/benchmark.json -k izzo2015